### PR TITLE
Fix stopping LiveDataProxy `onChange` subscriptions

### DIFF
--- a/src/data-proxy.ts
+++ b/src/data-proxy.ts
@@ -282,7 +282,7 @@ export class LiveDataProxy {
                     // Prepare db updates
                     const target = m.target;
                     if (target.length === 0) {
-                    // Overwrite this proxy's root value
+                        // Overwrite this proxy's root value
                         updates.push({ ref, target, value: cache, type: 'set', previous: m.previous });
                     }
                     else {
@@ -309,9 +309,9 @@ export class LiveDataProxy {
                         acebase_proxy: {
                             id: proxyId,
                             source: update.type,
-                        // update_id: ID.generate(),
-                        // batch_id: batchId,
-                        // batch_updates: updates.length
+                            // update_id: ID.generate(),
+                            // batch_id: batchId,
+                            // batch_updates: updates.length
                         },
                     };
                     await promise;

--- a/src/data-proxy.ts
+++ b/src/data-proxy.ts
@@ -463,7 +463,7 @@ export class LiveDataProxy {
             };
             localMutationsEmitter.on('mutations', mutationsHandler);
             const stop = () => {
-                localMutationsEmitter.off('mutations').off('mutations', mutationsHandler);
+                localMutationsEmitter.off('mutations', mutationsHandler);
                 clientSubscriptions.splice(clientSubscriptions.findIndex(cs => cs.stop === stop), 1);
             };
             clientSubscriptions.push({ target, stop });


### PR DESCRIPTION
Remove `.off('mutations')` call that clears all current subscriptions instead of just the one being stopped
Closes #30 