### PR TITLE
Import *  as Transport/Utils, then export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,11 @@ export { DebugLogger, LoggingLevel } from './debug';
 export { ID } from './id';
 export { PathReference } from './path-reference';
 export { EventStream, EventPublisher, EventSubscription } from './subscription';
-export * as Transport from './transport';
+import * as Transport from './transport.js';
+export {Transport}
 export { TypeMappings, TypeMappingOptions } from './type-mappings';
-export * as Utils from './utils';
+import * as Utils from './utils.js';
+export {Utils}
 export { PathInfo } from './path-info';
 export { ascii85 } from './ascii85';
 export { SimpleCache } from './simple-cache';


### PR DESCRIPTION
This is a minor change, I am using Acebase in an Expo project, but the bundler doesn't support the "export * as NAME from './file'" syntax. This change would make it so that Expo would be able to use acebase-client, without needing to change the node_modules folder manually.