### PR TITLE
Improve query option types

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -118,12 +118,13 @@ export interface QueryOptions {
     /**
      * callback function for events
      */
-    eventHandler?: (event: { name: string, [key: string]: any }) => boolean|void;
+    eventHandler?: (event: { name: 'add' | 'change' | 'remove'; path: string; value: any; } | { name: string;  [key: string]: any }) => boolean|void;
 
     /**
      * monitor changes
+     * @default false
      */
-    monitor?: {
+    monitor?: boolean | {
         /**
          * monitor new matches (either because they were added, or changed and now match the query)
          */


### PR DESCRIPTION
Add `boolean` type to `monitor` option, define possible `eventHandler` event names