### PR TITLE
Improvement: TS style schema object parser

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,18 +1,18 @@
 export interface IType {
-    typeOf: string, // typeof
+    typeOf: string; // typeof
     // eslint-disable-next-line @typescript-eslint/ban-types
-    instanceOf?: Function, // eg: instanceof 'Array'
-    value?:string|number|boolean|bigint|null,
-    genericTypes?: IType[],
-    children?: IProperty[],
-    matches?: RegExp // NEW: enforces regular expression checks on values
+    instanceOf?: Function; // eg: instanceof 'Array'
+    value?: string|number|boolean|bigint|null;
+    genericTypes?: IType[];
+    children?: IProperty[];
+    matches?: RegExp; // enforces regular expression checks on values
 }
 
 export interface IProperty {
-    name: string,
-    optional: boolean,
-    wildcard: boolean,
-    types: IType[]
+    name: string;
+    optional: boolean;
+    wildcard: boolean;
+    types: IType[];
 }
 
 // parses a typestring, creates checker functions

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -112,8 +112,11 @@ function parse(definition: string) {
                     const types = readTypes();
                     type.children.push({ name: prop.name, optional: prop.optional, wildcard: prop.wildcard, types });
                     consumeSpaces();
+                    if (definition[pos] === ';' || definition[pos] === ',') {
+                        consumeCharacter(definition[pos]);
+                        consumeSpaces();
+                    }
                     if (definition[pos] === '}') { break; }
-                    consumeCharacter(',');
                 }
                 consumeCharacter('}');
             }


### PR DESCRIPTION
Allow TypeScript style property `;` delimiters and trailing `;` or `,` delimiter when parsing schema objects. This will allow a schema objects like `{ prop1: boolean; prop2: number; }`