### PR TITLE
DataSnapshot `child` and `forEach` type improvements

### DIFF
--- a/src/data-reference.spec.ts
+++ b/src/data-reference.spec.ts
@@ -1,0 +1,27 @@
+// import { DataReference } from './data-reference';
+
+describe('DataReference', () => {
+    it('type checks', async () => {
+        // (this is not a unit test)
+        // Use this to perform DataReference typechecks,
+        // commented out to prevent TSC errors and warnings
+
+        // const ref = new DataReference<{ prop1: boolean; prop2: string; prop3: { sub1: string; sub2: boolean } }>(null, 'test');
+        // const snap = await ref.get();
+        // const val = snap.val();
+        // let boolean = val.prop1; // TSC: boolean
+        // let string = val.prop2; // TSC: string
+        // string = val.prop3.sub1; // TSC: string
+        // boolean = val.prop3.sub2; // TSC: boolean
+
+        // ref.set({ prop2: 'Hallo' }); // TSC: error
+        // ref.update({ prop2: 'Hallo' }); // TSC: ok
+
+        // boolean = snap.child('prop3').val().sub2; // TSC: boolean
+        // const anything = snap.child('prop/prop2').val().blah; // TSC: any
+        // snap.forEach((child) => {
+        //     const val = child.val(); // TSC: Type is T[keyof T]
+        //     return true;
+        // });
+    });
+});

--- a/src/data-snapshot.ts
+++ b/src/data-snapshot.ts
@@ -117,7 +117,7 @@ export class DataSnapshot<T = any> {
      * @param callback function that is called with a snapshot of each child node in this snapshot.
      * Must return a boolean value that indicates whether to continue iterating or not.
      */
-    forEach<Child extends DataSnapshot = DataSnapshot>(callback: (child: Child) => boolean): boolean {
+    forEach<Child extends DataSnapshot = DataSnapshot<T[keyof T]>>(callback: (child: Child) => boolean): boolean {
         const value = this.val();
         const prev = this.previous();
         return getChildren(this).every((key: never) => {

--- a/src/data-snapshot.ts
+++ b/src/data-snapshot.ts
@@ -175,7 +175,9 @@ export class MutationsDataSnapshot<Val = any, Prev = any, T extends IDataMutatio
      * @param index index of the mutation
      * @returns Returns a DataSnapshot of the mutated node
      */
-    child<Value = Val>(index: number): DataSnapshot<Value> {
+    child(key: string): never;
+    child<ChildType = T[number]>(index: number): DataSnapshot<ChildType>;
+    child(index: string | number) {
         if (typeof index !== 'number') { throw new Error('child index must be a number'); }
         const mutation = this.val()[index];
         const ref = mutation.target.reduce((ref, key) => ref.child(key), this.ref);

--- a/src/data-snapshot.ts
+++ b/src/data-snapshot.ts
@@ -81,7 +81,9 @@ export class DataSnapshot<T = any> {
      * @param path child key or path
      * @returns Returns a `DataSnapshot` of the child
      */
-    child<Value = any>(path: string | number): DataSnapshot<Value> {
+    child<Prop extends keyof T>(key: Prop): DataSnapshot<T[Prop]>;
+    child<ChildType = any>(path: string): ChildType extends keyof T ? DataSnapshot<T[ChildType]> : DataSnapshot<ChildType>;
+    child(path: string | number) {
         // Create new snapshot for child data
         const val = getChild(this, path, false);
         const prev = getChild(this, path, true);


### PR DESCRIPTION
In addition to @futurGH's great work to implement type generics in #34, I improved the types of the `DataSnapshot.child`, `DataSnapshot.forEach` and `MutationDataSnapshot.child` methods