### PR TITLE
Log caught errors in query event callbacks

### DIFF
--- a/src/data-reference.ts
+++ b/src/data-reference.ts
@@ -1336,7 +1336,14 @@ export class DataReferenceQuery {
                 }
                 ev = eventData;
             }
-            listeners.forEach(callback => { try { callback(ev); } catch(e) {} });
+            listeners.forEach(callback => {
+                try {
+                    callback(ev);
+                }
+                catch(err) {
+                    this.ref.db.debug.error(`Error executing "${ev.name}" event handler of realtime query on path "${this.ref.path}": ${err?.stack ?? err?.message ?? err}`);
+                }
+            });
         };
         // Check if there are event listeners set for realtime changes
         options.monitor = { add: false, change: false, remove: false };


### PR DESCRIPTION
These were previously silent, causing failing callbacks to be hard to debug.