### PR TITLE
Fix for Observable export since usage of tsc 5.0.4

### DIFF
--- a/src/optional-observable.ts
+++ b/src/optional-observable.ts
@@ -1,6 +1,5 @@
 import { getGlobalObject } from './utils';
-import type { Observable } from 'rxjs';
-export { Observable };
+export type { Observable } from 'rxjs';
 
 let _shimRequested = false;
 let _observable: any;
@@ -31,7 +30,7 @@ export function getObservable<T = any>() {
             'or call db.setObservable("shim") to suppress this warning'
         );
     }
-    if (_observable) { return _observable as typeof Observable<T>; }
+    if (_observable) { return _observable as typeof import('rxjs').Observable<T>; }
     throw new Error('RxJS Observable could not be loaded. ');
 }
 


### PR DESCRIPTION
Apps using acebase(/-core) with typescript version < 5.0 and `skipLibCheck` set to `false` would get error: 
```
[Error: node_modules/acebase-core/dist/types/optional-observable.d.ts:5:68 - error TS1144: '{' or ';' expected.
export declare function getObservable<T = any>(): typeof Observable<T>;
                                                                   ^
```

This was introduced when acebase-core started using typescript 5.0.4