### PR TITLE
Add caseSensitive option to create index typings

### DIFF
--- a/src/acebase-base.ts
+++ b/src/acebase-base.ts
@@ -215,6 +215,11 @@ export abstract class AceBaseBase extends SimpleEventEmitter {
                     include?: string[];
                     /** If the indexed values are strings, which default locale to use */
                     textLocale?: string;
+                    /**
+                     * Whether the values are indexed with case sensitivity or not (applies to string values only)
+                     * @default false
+                     */
+                    caseSensitive?: boolean
                     /** additional index-specific configuration settings */
                     config?: any;
                 }) => {


### PR DESCRIPTION
Expose the missing `caseSensitive` option in `indexes.create` TypeScript typings for string indexes.

This option is already supported internally by AceBase index creation but was not available in the public Function type definitions.

Also documented the default behavior:

* `caseSensitive` defaults to `false`
* applies to string indexed values only

Refs:

* [https://github.com/appy-one/acebase#other-indexing-options](https://github.com/appy-one/acebase#other-indexing-options)
* [https://github.com/appy-one/acebase-core/blob/master/src/api.ts](https://github.com/appy-one/acebase-core/blob/master/src/api.ts)